### PR TITLE
sys_domain records do not generate static error pages

### DIFF
--- a/class.tx_static404.php
+++ b/class.tx_static404.php
@@ -39,6 +39,13 @@ class tx_static404 {
 	 */
 	static public $TEMP_FILENAME_PREFIX = 'tx_static404-';
 
+	private $extConf = null;
+
+	public function __construct() {
+		// load the extension configuration
+		$this->extConf = unserialize($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf']['static_404']);
+	}
+
 	/**
 	 * This function will be called by the clearCachePostProc hook
 	 *
@@ -72,15 +79,12 @@ class tx_static404 {
 		/** @var \TYPO3\CMS\Core\Authentication\BackendUserAuthentication $beUser */
 		$beUser =  $GLOBALS['BE_USER'];
 
-		// load the extension configuration
-		$extConf = unserialize($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf']['static_404']);
-
-		if (!is_array($extConf) || empty($extConf['all404Pids'])) {
+		if (!is_array($this->extConf) || empty($this->extConf['all404Pids'])) {
 			throw new \TYPO3\CMS\Core\Error\Exception('The extension is not properly configured. Please visit the configuration tab in the extension manager');
 		}
 
 		// extract each page id
-		$pageUids = GeneralUtility::intExplode(',', $extConf['all404Pids'], true);
+		$pageUids = GeneralUtility::intExplode(',', $this->extConf['all404Pids'], true);
 		if (empty($pageUids) || !$pageUids[0]) {
 			throw new \TYPO3\CMS\Core\Error\Exception('Unable to find a valid 404 pid in the configuration. Please visit the configuration tab in the extension manager');
 		}
@@ -160,7 +164,8 @@ class tx_static404 {
 
 			// Find every sys_domain records configured in page rootline
 			foreach ($rootLine as $row) {
-				$dRec = \TYPO3\CMS\Backend\Utility\BackendUtility::getRecordsByField('sys_domain', 'pid', $row['uid'], ' AND redirectTo=\'\' AND hidden=0', '', 'sorting');
+				$constraint = ($this->extConf['excludeDomainsWithRedirect'] ? ' AND redirectTo=\'\' AND hidden=0' : ' AND hidden=0');
+				$dRec = \TYPO3\CMS\Backend\Utility\BackendUtility::getRecordsByField('sys_domain', 'pid', $row['uid'], $constraint, '', 'sorting');
 
 				if (is_array($dRec)) {
 					foreach ($dRec as $dRecord) {

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -3,3 +3,6 @@ all404Pids =
 
 # cat=basic/enable; type=boolean; label=Disable pageNotFound_handling hook: Delegate handling hook to an other plugin
 disablePageNotFound_handling = 0
+
+# cat=basic/enable; type=boolean; label=Do not generate static 404 pages for domain records with a redirect
+excludeDomainsWithRedirect = 1


### PR DESCRIPTION
my setup is:
- realurl 
- sys_domain records which do a redirect (e.g. redirect from example.com to www.example.com)

In this case, no static page is generated for example.com

Why did you filter out domains with a redirect?
Is this the correct way to fix this issue or should it be fixed in realurl?

I don't want to workaround with RewriteRules as installations with a massive amount of alternative domains are easier to maintain with the domain records in TYPO3 ;)
